### PR TITLE
Speed up Este-PINTOOL by changing Proc->images from vector to map

### DIFF
--- a/Este/src/include/Este/proc.hpp
+++ b/Este/src/include/Este/proc.hpp
@@ -102,7 +102,7 @@ namespace Ctx {
 		Sync::RW _serial_trace_lock;
 
 		// All images loaded
-		std::vector<Image> images;
+		std::map<ADDRINT, Image> images;
 
 		// All routines encountered
 		// starting address : rtn object

--- a/web/server.py
+++ b/web/server.py
@@ -84,6 +84,9 @@ def serve(port:int) -> None:
     SERVER = HTTPServer(
         server_address = ('', port), 
         RequestHandlerClass = EsteServerHandler)
+    SERVER.RequestHandlerClass.extensions_map.update({
+      ".js": "application/javascript",
+    })
 
     try:
         logging.info(f'Starting Este server at port {port}...\n')


### PR DESCRIPTION
Fixed bug in server.py where .js files are served as text/html

Signed-off-by: Julia <julia.poo.poo.poo@gmail.com>